### PR TITLE
github workflowのpythonバージョンを修正した

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.10.8
+          python-version: 3.11.1
           architecture: x64
       - name: Checkout PyTorch
         uses: actions/checkout@master


### PR DESCRIPTION
## 概要

指定されたバージョンのpythonが存在しないため修正した。
<img width="570" alt="スクリーンショット 2022-12-17 13 55 47" src="https://user-images.githubusercontent.com/113601/208225878-6b1758c2-5300-4a4a-b68d-b025c0713364.png">
